### PR TITLE
 Fix updateGroup XML (malformed CDATA section in <olddescription/>) 

### DIFF
--- a/CMUChangeLogConsumer/src/edu/cmu/grouper/changelog/consumer/ConsumerMain.java
+++ b/CMUChangeLogConsumer/src/edu/cmu/grouper/changelog/consumer/ConsumerMain.java
@@ -299,7 +299,7 @@ public class ConsumerMain extends ChangeLogConsumerBase {
 		mesg = mesg + "<description><![CDATA[" + groupDescription
 				+ "]]></description>";
 		mesg = mesg + "<olddescription><![CDATA[" + groupOldDescription
-				+ "</olddescription>";
+				+ "]]></olddescription>";
 		return mesg;
 	}
 


### PR DESCRIPTION
At present, the updateGroup XML produced by getGroupUpdatedMessage() includes a malformed CDATA section in the <olddescription/> element.  This pull request fixes the problem by closing the CDATA section just before closing the element.